### PR TITLE
fix(migrations): enable RLS and add missing policies for us_states/us_state_selections

### DIFF
--- a/apps/web/supabase/migrations/20260130123000_enable_rls_and_policies.sql
+++ b/apps/web/supabase/migrations/20260130123000_enable_rls_and_policies.sql
@@ -1,0 +1,65 @@
+-- Enable RLS and ensure anonymous policies exist (idempotent)
+-- Created to ensure RLS and full policy coverage for us_states and us_state_selections
+
+ALTER TABLE IF EXISTS public.us_states ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.us_state_selections ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname='public' AND tablename='us_states'
+      AND policyname='Allow anonymous read access to us_states'
+  ) THEN
+    EXECUTE 'CREATE POLICY "Allow anonymous read access to us_states"\n  ON public.us_states FOR SELECT TO anon USING (true);';
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname='public' AND tablename='us_state_selections'
+      AND policyname='Allow anonymous read access to us_state_selections'
+  ) THEN
+    EXECUTE 'CREATE POLICY "Allow anonymous read access to us_state_selections"\n  ON public.us_state_selections FOR SELECT TO anon USING (true);';
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname='public' AND tablename='us_state_selections'
+      AND policyname='Allow anonymous insert to us_state_selections'
+  ) THEN
+    EXECUTE 'CREATE POLICY "Allow anonymous insert to us_state_selections"\n  ON public.us_state_selections FOR INSERT TO anon WITH CHECK (true);';
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname='public' AND tablename='us_state_selections'
+      AND policyname='Allow anonymous update to us_state_selections'
+  ) THEN
+    EXECUTE 'CREATE POLICY "Allow anonymous update to us_state_selections"\n  ON public.us_state_selections FOR UPDATE TO anon USING (true);';
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname='public' AND tablename='us_state_selections'
+      AND policyname='Allow anonymous delete from us_state_selections'
+  ) THEN
+    EXECUTE 'CREATE POLICY "Allow anonymous delete from us_state_selections"\n  ON public.us_state_selections FOR DELETE TO anon USING (true);';
+  END IF;
+END
+$$;

--- a/apps/web/supabase/migrations/20260130123000_enable_rls_and_policies.sql
+++ b/apps/web/supabase/migrations/20260130123000_enable_rls_and_policies.sql
@@ -11,7 +11,7 @@ BEGIN
     WHERE schemaname='public' AND tablename='us_states'
       AND policyname='Allow anonymous read access to us_states'
   ) THEN
-    EXECUTE 'CREATE POLICY "Allow anonymous read access to us_states"\n  ON public.us_states FOR SELECT TO anon USING (true);';
+    EXECUTE 'CREATE POLICY "Allow anonymous read access to us_states" ON public.us_states FOR SELECT TO anon USING (true);';
   END IF;
 END
 $$;
@@ -23,7 +23,7 @@ BEGIN
     WHERE schemaname='public' AND tablename='us_state_selections'
       AND policyname='Allow anonymous read access to us_state_selections'
   ) THEN
-    EXECUTE 'CREATE POLICY "Allow anonymous read access to us_state_selections"\n  ON public.us_state_selections FOR SELECT TO anon USING (true);';
+    EXECUTE 'CREATE POLICY "Allow anonymous read access to us_state_selections" ON public.us_state_selections FOR SELECT TO anon USING (true);';
   END IF;
 END
 $$;
@@ -35,7 +35,7 @@ BEGIN
     WHERE schemaname='public' AND tablename='us_state_selections'
       AND policyname='Allow anonymous insert to us_state_selections'
   ) THEN
-    EXECUTE 'CREATE POLICY "Allow anonymous insert to us_state_selections"\n  ON public.us_state_selections FOR INSERT TO anon WITH CHECK (true);';
+    EXECUTE 'CREATE POLICY "Allow anonymous insert to us_state_selections" ON public.us_state_selections FOR INSERT TO anon WITH CHECK (true);';
   END IF;
 END
 $$;
@@ -47,7 +47,7 @@ BEGIN
     WHERE schemaname='public' AND tablename='us_state_selections'
       AND policyname='Allow anonymous update to us_state_selections'
   ) THEN
-    EXECUTE 'CREATE POLICY "Allow anonymous update to us_state_selections"\n  ON public.us_state_selections FOR UPDATE TO anon USING (true);';
+    EXECUTE 'CREATE POLICY "Allow anonymous update to us_state_selections" ON public.us_state_selections FOR UPDATE TO anon USING (true);';
   END IF;
 END
 $$;
@@ -59,7 +59,7 @@ BEGIN
     WHERE schemaname='public' AND tablename='us_state_selections'
       AND policyname='Allow anonymous delete from us_state_selections'
   ) THEN
-    EXECUTE 'CREATE POLICY "Allow anonymous delete from us_state_selections"\n  ON public.us_state_selections FOR DELETE TO anon USING (true);';
+    EXECUTE 'CREATE POLICY "Allow anonymous delete from us_state_selections" ON public.us_state_selections FOR DELETE TO anon USING (true);';
   END IF;
 END
 $$;


### PR DESCRIPTION
This PR adds an idempotent migration to enable RLS and ensure anonymous policies for `us_states` and `us_state_selections`.

What changed:
- Added migration:  (idempotent checks).

Why:
- RLS was disabled on preview/dev causing security and behavior mismatches.

Verification performed locally:
-  applied migrations and seeds locally.
- Playwright E2E: 6 tests passed across Chromium/Firefox/WebKit (local Docker run, ~3.6s).

How to verify in preview (after PR merge):
- Run the following SQL in the preview DB to confirm migrations and RLS/policies:



Notes:
- Migration is additive and idempotent.
- If you'd like, I can merge after a quick review and run preview verification when the preview deploy is ready.

Co-authored-by: automated-assistant